### PR TITLE
Adds drone based automation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,60 @@
+pipeline:
+  build-debs:
+    when:
+      event: tag
+    image: gcr.io/admobilize-testing/builder-qemu:latest
+    privileged: true
+    mountimg: ${MOUNTIMG}
+    mountoffset: ${MOUNTOFFSET}
+    body: |
+      apt-get update
+      apt-get install --yes wiringpi libftdi-dev
+      debuild -us -uc -b
+      mv ../*.deb .
+
+  upload-debs:
+    when:
+      event: tag
+    image: gcr.io/admobilize-testing/gce-builder:latest
+    secrets: [aws_access_key_id, aws_secret_access_key]
+    commands:
+      - gsutil cp ./*.deb gs://raspbian-images/
+      - deb-s3 upload --bucket packages.matrixlabs.ai 
+        --prefix $DISTRIBUTION
+        --codename $CODENAME
+        --access-key-id $${AWS_ACCESS_KEY_ID}
+        --secret-access-key $${AWS_SECRET_ACCESS_KEY}
+        ./*.deb
+
+  notify-always:
+    image: plugins/slack
+    secrets: [slack_webhook]
+    username: drone-ci-builder
+    channel: notifications
+    when:
+      status: [ success, failure ]
+      event: tag 
+    template: |
+      {{#success build.status}}
+        {{build.author}} just built `{{repo.name}}:{{build.branch}}` from <{{repo.link}}|#{{truncate build.commit 8}}>
+        :new: {{build.message}}
+        :debian: The new `matrixio-xc3sprog_{{drone.tag}}_armhf.deb` was created
+      {{else}}
+        {{build.author}} just broke the build of `{{repo.name}}:{{build.branch}}` with <{{repo.link}}|#{{truncate build.commit 8}}>
+        :new: :zombie: {{build.message}}
+      {{/success}}
+      :stopwatch: {{ since build.started}}
+      :gear: {{build.link}}
+
+matrix:
+  include: 
+    - CODENAME: jessie
+      DISTRIBUTION: raspbian
+      MOUNTOFFSET: 48234496
+      MOUNTDIR: /drone/src/github.com/matrix-io/xc3sprog
+      MOUNTIMG: https://storage.googleapis.com/raspbian-images/2017-07-05-raspbian-jessie-debuild.img.gz
+    - CODENAME: stretch
+      MOUNTOFFSET: 48234496
+      MOUNTDIR: /drone/src/github.com/matrix-io/xc3sprog
+      DISTRIBUTION: raspbian
+      MOUNTIMG: https://storage.googleapis.com/raspbian-images/2017-08-16-raspbian-stretch-debuild.img.gz

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,24 @@
-matrixio-xc3sprog (1.1.1) unstable; urgency=medium
+xc3sprog (1.1.1) unstable; urgency=medium
 
   * MATRIX Voice support added
 
  --  <andres.calderon@admobilize.com>  Thu, 31 Aug 2017 14:33:36 +0000
 
+xc3sprog (1.1) unstable; urgency=medium
+
+  * Adding Support for MATRIX_Voice
+
+ -- Kevin Patino <kevin.patino@admobilize.com>  Mon, 20 Feb 2017 16:01:18 +0000
+
+xc3sprog (1.0.0.001-2) unstable; urgency=medium
+
+  * Adding README. Not really useful: we are testing Debian
+  packaging workflow.
+
+ --  <pi@raspberrypi>  Thu, 01 Sep 2016 07:27:35 -0800
+
+xc3sprog (1.0.0.001-1) unstable; urgency=low
+
+  * Initial release (Closes: #nnnn)  <nnnn is the bug number of your ITP>
+
+ -- unknown <pi@unknown>  Tue, 12 Jul 2016 17:10:06 -0800

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,23 +1,23 @@
-xc3sprog (1.1.1) unstable; urgency=medium
+matrixio-xc3sprog (1.1.1) unstable; urgency=medium
 
   * MATRIX Voice support added
 
  --  <andres.calderon@admobilize.com>  Thu, 31 Aug 2017 14:33:36 +0000
 
-xc3sprog (1.1) unstable; urgency=medium
+matrixio-xc3sprog (1.1) unstable; urgency=medium
 
   * Adding Support for MATRIX_Voice
 
  -- Kevin Patino <kevin.patino@admobilize.com>  Mon, 20 Feb 2017 16:01:18 +0000
 
-xc3sprog (1.0.0.001-2) unstable; urgency=medium
+matrixio-xc3sprog (1.0.0.001-2) unstable; urgency=medium
 
   * Adding README. Not really useful: we are testing Debian
   packaging workflow.
 
  --  <pi@raspberrypi>  Thu, 01 Sep 2016 07:27:35 -0800
 
-xc3sprog (1.0.0.001-1) unstable; urgency=low
+matrixio-xc3sprog (1.0.0.001-1) unstable; urgency=low
 
   * Initial release (Closes: #nnnn)  <nnnn is the bug number of your ITP>
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,24 +1,6 @@
-xc3sprog (1.1.1) unstable; urgency=medium
+matrixio-xc3sprog (1.1.1) unstable; urgency=medium
 
   * MATRIX Voice support added
 
  --  <andres.calderon@admobilize.com>  Thu, 31 Aug 2017 14:33:36 +0000
 
-xc3sprog (1.1) unstable; urgency=medium
-
-  * Adding Support for MATRIX_Voice
-
- -- Kevin Patino <kevin.patino@admobilize.com>  Mon, 20 Feb 2017 16:01:18 +0000
-
-xc3sprog (1.0.0.001-2) unstable; urgency=medium
-
-  * Adding README. Not really useful: we are testing Debian
-  packaging workflow.
-
- --  <pi@raspberrypi>  Thu, 01 Sep 2016 07:27:35 -0800
-
-xc3sprog (1.0.0.001-1) unstable; urgency=low
-
-  * Initial release (Closes: #nnnn)  <nnnn is the bug number of your ITP>
-
- -- unknown <pi@unknown>  Tue, 12 Jul 2016 17:10:06 -0800

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: xc3sprog
+Source: matrixio-xc3sprog
 Section: embedded
 Priority: optional
 Maintainer: Admobilize <info@admobilize.com>
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9), cmake, wiringpi, libftdi-dev
 Standards-Version: 3.9.5
 Homepage: https://github.com/matrix-io/xc3sprog
 
-Package: xc3sprog
+Package: matrixio-xc3sprog
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, wiringpi
 Description: Spartan3, XCF and CPLD JTAG programmer and other utilities.


### PR DESCRIPTION
Adds automatic package building based on qemu on drone CI. 

WARNING: Changes the package name from `xc3sprog`  to `matrixio-xc3sprog`. We need to add a rule to the debian package to cleanup the previous package on install. 