### PR TITLE
Update progalgspiflash.cpp for Macronix MX25L32

### DIFF
--- a/progalgspiflash.cpp
+++ b/progalgspiflash.cpp
@@ -370,6 +370,9 @@ int ProgAlgSPIFlash::spi_flashinfo_m25p_mx25l(unsigned char *buf, int is_mx25l)
                 fbuf[1], fbuf[2]);
         switch (fbuf[2])
           {
+          case 0x16: // Adding support for new flash Macronix MX25L32
+            pages = 16384;
+            break;
           case 0x17:
             pages = 262144;
             sector_size = 65536;


### PR DESCRIPTION
We are using the new flash memory Macronix MX25L32, and found that the above change allows it to be recognized.
Would be nice to have this in the package, thanks.