### PR TITLE
Defualt wiringpi to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ ADD_CUSTOM_COMMAND(OUTPUT cables.h
 
 INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
-option(USE_WIRINGPI "Use WiringPi" ON)
+option(USE_WIRINGPI "Use WiringPi" OFF)
 
 if(USE_WIRINGPI)
     set (CONDITIONAL_FILES ${CONDITIONAL_FILES} "iomatrixcreator.cpp" "iomatrixvoice.cpp" "iowiringpi.cpp")


### PR DESCRIPTION
The default is for wiringpi on at all times, this should be off and settable. Maybe even detect if running on a Pi?