### PR TITLE
Update progalgspiflash.cpp to add Numonyx N25Q 0x16

### DIFF
--- a/progalgspiflash.cpp
+++ b/progalgspiflash.cpp
@@ -445,6 +445,10 @@ int ProgAlgSPIFlash::spi_flashinfo_m25p_mx25l(unsigned char *buf, int is_mx25l)
                 fbuf[1], fbuf[2]);
         switch (fbuf[2])
           {
+	case 0x16:
+            pages = 16384;
+            sector_size = 65536;
+            break;
           case 0x17:
             pages = 32768;
             sector_size = 65536;


### PR DESCRIPTION
Add Numonyx N25Q device 0x16 which is used on Digilent CMOD A7 artix7 fpga board.