### PR TITLE
Fix compilation under FreeBSD

### DIFF
--- a/utilities.cpp
+++ b/utilities.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
+#include <unistd.h>
 #include <memory>
 
 #include "ioparport.h"


### PR DESCRIPTION
Without this usleep() is not declared and the build explodes.
