### PR TITLE
Fix for reference to 'byte' is ambiguous.

### DIFF
--- a/bitfile.cpp
+++ b/bitfile.cpp
@@ -35,8 +35,6 @@ Dmitry Teytelman [dimtey@gmail.com] 14 Jun 2006 [applied 13 Aug 2006]:
 #include <time.h>
 #include "bitrev.h"
 
-using namespace std;
-
 BitFile::BitFile()
   : length(0)
   , buffer(0)
@@ -607,14 +605,14 @@ uint32_t BitFile::saveAs(FILE_STYLE style, const char  *device,
   return clip;
 }
 
-void BitFile::error(const string &str)
+void BitFile::error(const std::string &str)
 {
   errorStr=str;
   Error=true;
   fprintf(logfile,"%s\n",str.c_str());
 }
 
-void BitFile::readField(string &field, FILE *fp)
+void BitFile::readField(std::string &field, FILE *fp)
 {
   byte t[2];
   fread(t,1,2,fp); 

--- a/srecfile.cpp
+++ b/srecfile.cpp
@@ -28,8 +28,6 @@ Modifyied from srecdec
 #include <string.h>
 #include <stdlib.h>
 
-using namespace std;
-
 int SrecFile::DecodeSRecordLine(char *source, unsigned char *dest, S_Record *SRec)
 {
   char buffer[16];


### PR DESCRIPTION
Removes 'using namespace std' from bitfile and srecfile.

Was not needed, and caused build errors with latest GCC.

Fixes matrix-io/xc3sprog#29.