### PR TITLE
Added support for more SPI flash

### DIFF
--- a/progalgspiflash.h
+++ b/progalgspiflash.h
@@ -60,6 +60,7 @@ class ProgAlgSPIFlash
   int xc_user(byte *in, byte *out, int len);
   int spi_xfer_user1(uint8_t *last_miso, int miso_len, int miso_skip, 
 		     uint8_t *mosi, int mosi_len, int preamble);
+  int spi_flashinfo_amd (unsigned char * fbuf);
   int spi_flashinfo_s33 (unsigned char * fbuf);
   int spi_flashinfo_amic (unsigned char * fbuf);
   int spi_flashinfo_amic_quad (unsigned char * fbuf);


### PR DESCRIPTION
Includes same changes as #26, which adds support for SPI flash in the popular [Digilent CmodA7 FPGA module](https://reference.digilentinc.com/programmable-logic/cmod-a7/start).  This PR also adds support for the SPI flash contained in the [Enclustra Mars AX3 FPGA module](https://www.enclustra.com/en/products/fpga-modules/mars-ax3/).