### PR TITLE
[CABLELIST] add option string to 'saturn' cable, 

### DIFF
--- a/cablelist.txt
+++ b/cablelist.txt
@@ -9,7 +9,7 @@
 ftdi          ftdi    1500000 0x0403:0x6010:                                    
 papilio       ftdi    6000000 0x0403:0x6010: 
 minila        ftdi     800000 0x0403:0x6010:
-saturn        ftdi    6000000 0x0403:0x6010:
+saturn        ftdi    6000000 0x0403:0x6010:Saturn Spartan 6 FPGA Module::0:0x00:0x0B:0x00:0x00
 ft232h        ftdi    1500000 0x0403:0x6014:                                      
 ft4232h       ftdi    1500000 0x0403:0x6011:
 cm1           ftdi    1500000 0x0403:0x8350:


### PR DESCRIPTION
## Current status:
* The `saturn` cable is only defined using the `ftdi` port and default PID, VID. See [cablelist.txt](./cablelist.txt)

## Current issue:
* any other factory-default FTDI devices plugged in to the computer will be detached as part of the discovery method.
* there is currently no difference between a factory-default FTDI device and the way `saturn` cable is defined.

## Goal: 
* ensure a 100% match when discovering potential USB devices.
* do not detach other FTDI by mistake

## Fix:
* add option string to [cablelist.txt](./cablelist.txt) file


XC3SPROG cablelist.txt option format (refer to ioftdi.cpp, function IOFtdi::Init):
```
:vendor  :product  :description                   :channel  :dbus_data  :dbus_en  :cbus_data  :cbus_en
:0x0403  :0x6010   :Saturn Spartan 6 FPGA Module  :0        :0x00       :0x0B     :0x00       :0x00
```

`saturn` product page: https://numato.com/product/saturn-spartan-6-fpga-development-board-with-ddr-sdram/